### PR TITLE
added persistent preferences

### DIFF
--- a/packages/pubg-ui-theme/src/components/routes/play.tsx
+++ b/packages/pubg-ui-theme/src/components/routes/play.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Typography from 'components/typography';
 import styled from 'styled';
+import { withPreferences, PreferenceProps, Region, SquadSize, Perspective } from 'pubg-ui';
 
 const Button = styled.button`
   padding: ${props => props.theme.unit(1)};
@@ -16,16 +17,6 @@ const Play = styled.div`
   flex-direction: column;
 `;
 
-type Region =
-| 'na'
-| 'eu'
-| 'as'
-| 'jp'
-| 'oc'
-| 'sa'
-| 'sea'
-;
-
 const regionMap: { [key in Region]: string } = {
   na: 'North America',
   eu: 'Europe',
@@ -36,70 +27,35 @@ const regionMap: { [key in Region]: string } = {
   sea: 'Sea'
 };
 
-type Squad =
-  | 'solo'
-  | 'duo'
-  | 'squad'
-;
-
-const squadMap: { [key in Squad]: string } = {
+const squadMap: { [key in SquadSize]: string } = {
   solo: 'Solo',
   duo: 'Duo',
   squad: 'Squad'
 };
 
-type Mode =
-  | 'tpp'
-  | 'fpp'
-;
-
-const modeMap: { [key in Mode]: string } = {
-  fpp: 'First-Person',
-  tpp: 'Third-Person'
+const perspectiveMap: { [key in Perspective]: string } = {
+  'first-person': 'First-Person',
+  'third-person': 'Third-Person'
 };
 
 interface Props { }
 
-interface State {
-  region: Region;
-  squad: Squad;
-  mode: Mode;
-}
-
-export class PlayComponent extends React.Component<Props, State> {
+export class PlayComponent extends React.Component<Props & PreferenceProps> {
 
   constructor() {
     super();
-
-    this.state = {
-      region: 'na',
-      squad: 'solo',
-      mode: 'fpp'
-    };
-  }
-
-  setRegion(region: Region) {
-    this.setState({ region });
-  }
-
-  setSquad(squad: Squad) {
-    this.setState({ squad });
-  }
-
-  setMode(mode: Mode) {
-    this.setState({ mode });
   }
 
   renderRegions() {
     return Object.keys(regionMap).map((region: Region) => {
       const regionName = regionMap[region];
-      const className = region === this.state.region ? 'active' : '';
+      const className = region === this.props.preferences.region ? 'active' : '';
 
       return (
         <Button
           key={region}
           className={className}
-          onClick={() => this.setRegion(region)}
+          onClick={() => this.props.setPreference('region', region)}
         >
           {regionName}
         </Button>
@@ -108,15 +64,15 @@ export class PlayComponent extends React.Component<Props, State> {
   }
 
   renderSquads() {
-    return Object.keys(squadMap).map((squad: Squad) => {
+    return Object.keys(squadMap).map((squad: SquadSize) => {
       const squadName = squadMap[squad];
-      const className = squad === this.state.squad ? 'active' : '';
+      const className = squad === this.props.preferences.squad ? 'active' : '';
 
       return (
         <Button
           key={squad}
           className={className}
-          onClick={() => this.setSquad(squad)}
+          onClick={() => this.props.setPreference('squad', squad)}
         >
           {squadName}
         </Button>
@@ -124,18 +80,18 @@ export class PlayComponent extends React.Component<Props, State> {
     });
   }
 
-  renderModes() {
-    return Object.keys(modeMap).map((mode: Mode) => {
-      const modeName = modeMap[mode];
-      const className = mode === this.state.mode ? 'active' : '';
+  renderPerspectives() {
+    return Object.keys(perspectiveMap).map((perspective: Perspective) => {
+      const perspectiveName = perspectiveMap[perspective];
+      const className = perspective === this.props.preferences.perspective ? 'active' : '';
 
       return (
         <Button
-          key={mode}
+          key={perspective}
           className={className}
-          onClick={() => this.setMode(mode)}
+          onClick={() => this.props.setPreference('perspective', perspective)}
         >
-          {modeName}
+          {perspectiveName}
         </Button>
       );
     });
@@ -154,11 +110,11 @@ export class PlayComponent extends React.Component<Props, State> {
       </div>
       <Typography type="main-sm">Perspective</Typography>
       <div>
-        {this.renderModes()}
+        {this.renderPerspectives()}
       </div>
       </Play>
     );
   }
 }
 
-export default PlayComponent;
+export default withPreferences<Props>(PlayComponent);

--- a/packages/pubg-ui/src/Provider/auth.ts
+++ b/packages/pubg-ui/src/Provider/auth.ts
@@ -1,8 +1,0 @@
-export interface Authentication {
-  accessToken: string;      // 468 character hex string
-  appId: string;            // "578080"
-  platformType: string;     // "Steam"
-  playerNetId: string;      // "76561197988861..."
-  userDisplayName: string;  // steam name
-  userSerial: string;       // "76561197988861..."
-}

--- a/packages/pubg-ui/src/Provider/context.ts
+++ b/packages/pubg-ui/src/Provider/context.ts
@@ -1,7 +1,0 @@
-import { Authentication } from  './auth';
-
-export interface ProviderContext {
-  pubg: {
-    auth: Authentication | null;
-  };
-}

--- a/packages/pubg-ui/src/Provider/index.ts
+++ b/packages/pubg-ui/src/Provider/index.ts
@@ -1,3 +1,2 @@
 export { default } from './Provider';
-export { Authentication } from './auth';
-export { ProviderContext } from './context';
+export { Authentication, ProviderContext } from './interfaces';

--- a/packages/pubg-ui/src/Provider/interfaces.ts
+++ b/packages/pubg-ui/src/Provider/interfaces.ts
@@ -1,0 +1,27 @@
+import { PreferenceOptions, Region, SquadSize, Perspective, SetPreference } from '../preferences';
+
+export interface Authentication {
+  accessToken: string;      // 468 character hex string
+  appId: string;            // "578080"
+  platformType: string;     // "Steam"
+  playerNetId: string;      // "76561197988861..."
+  userDisplayName: string;  // steam name
+  userSerial: string;       // "76561197988861..."
+}
+
+export interface ProviderState {
+  auth: Authentication | null;
+  preference: PreferenceOptions;
+}
+
+export interface ProviderContext {
+  pubg: {
+    auth: Authentication | null;
+    preference: PreferenceOptions;
+    action: ProviderAction;
+  };
+}
+
+export interface ProviderAction {
+  setPreference: SetPreference;
+}

--- a/packages/pubg-ui/src/Provider/preferences.ts
+++ b/packages/pubg-ui/src/Provider/preferences.ts
@@ -1,0 +1,19 @@
+// import { PreferenceOptions } from './interfaces';
+//
+// const LOCALSTORAGE_KEY = 'pubg-ui-preferences';
+//
+// export const getPreferences = (): Partial<Preference> => {
+//   try {
+//     const raw = window.localStorage.getItem(LOCALSTORAGE_KEY) || '';
+//
+//     return JSON.parse(raw) as Partial<Preference>;
+//   } catch (error) {
+//     return {};
+//   }
+// };
+//
+// export const setPreferences = (preferences: Preference) => {
+//   const json = JSON.stringify(preferences);
+//
+//   window.localStorage.setItem(LOCALSTORAGE_KEY, json);
+// };

--- a/packages/pubg-ui/src/Provider/types.ts
+++ b/packages/pubg-ui/src/Provider/types.ts
@@ -1,0 +1,24 @@
+// import { Preference } from './interfaces';
+//
+// export type Region =
+//   | 'na'
+//   | 'eu'
+//   | 'as'
+//   | 'jp'
+//   | 'oc'
+//   | 'sa'
+//   | 'sea'
+// ;
+//
+// export type SquadSize =
+//   | 'solo'
+//   | 'duo'
+//   | 'squad'
+// ;
+//
+// export type Perspective =
+//   | 'first-person'
+//   | 'third-person'
+// ;
+//
+// export type SetPreference = (key: keyof Preference, value: string) => void;

--- a/packages/pubg-ui/src/index.ts
+++ b/packages/pubg-ui/src/index.ts
@@ -3,3 +3,4 @@ export { default as PlayerName } from './PlayerName';
 export { default as PubgProvider } from './Provider';
 export * from './Provider';
 export { default as Version } from './Version';
+export * from './preferences';

--- a/packages/pubg-ui/src/preferences/index.ts
+++ b/packages/pubg-ui/src/preferences/index.ts
@@ -1,0 +1,4 @@
+export { withPreferences, PreferenceProps } from './withPreferences';
+export * from './interfaces';
+export * from './types';
+export * from './persist'

--- a/packages/pubg-ui/src/preferences/interfaces.ts
+++ b/packages/pubg-ui/src/preferences/interfaces.ts
@@ -1,0 +1,7 @@
+import { Region, SquadSize, Perspective } from './types';
+
+export interface PreferenceOptions {
+  region: Region;
+  squad: SquadSize;
+  perspective: Perspective;
+}

--- a/packages/pubg-ui/src/preferences/persist.ts
+++ b/packages/pubg-ui/src/preferences/persist.ts
@@ -1,0 +1,19 @@
+import { PreferenceOptions } from './interfaces';
+
+const LOCALSTORAGE_KEY = 'pubg-ui-preferences';
+
+export const getPreferences = (): Partial<PreferenceOptions> => {
+  try {
+    const raw = window.localStorage.getItem(LOCALSTORAGE_KEY) || '';
+
+    return JSON.parse(raw) as Partial<PreferenceOptions>;
+  } catch (error) {
+    return {};
+  }
+};
+
+export const setPreferences = (preferences: PreferenceOptions) => {
+  const json = JSON.stringify(preferences);
+
+  window.localStorage.setItem(LOCALSTORAGE_KEY, json);
+};

--- a/packages/pubg-ui/src/preferences/types.ts
+++ b/packages/pubg-ui/src/preferences/types.ts
@@ -1,0 +1,24 @@
+import { PreferenceOptions } from './interfaces';
+
+export type Region =
+  | 'na'
+  | 'eu'
+  | 'as'
+  | 'jp'
+  | 'oc'
+  | 'sa'
+  | 'sea'
+;
+
+export type SquadSize =
+  | 'solo'
+  | 'duo'
+  | 'squad'
+;
+
+export type Perspective =
+  | 'first-person'
+  | 'third-person'
+;
+
+export type SetPreference = (key: keyof PreferenceOptions, value: string) => void;

--- a/packages/pubg-ui/src/preferences/withPreferences.tsx
+++ b/packages/pubg-ui/src/preferences/withPreferences.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { PreferenceOptions } from './interfaces';
+import { SetPreference } from './types';
+import { ProviderContext } from '../Provider';
+
+export interface PreferenceProps {
+  preferences: PreferenceOptions;
+  setPreference: SetPreference;
+}
+
+export const withPreferences = <P extends {}>(Component: React.ComponentType<P & Partial<PreferenceProps>>) => {
+  const C: React.SFC<P & Partial<PreferenceProps>> = (props, context: ProviderContext) => (
+    <Component {...props} preferences={context.pubg.preference} setPreference={context.pubg.action.setPreference} />
+  );
+
+  C.contextTypes = {
+    pubg: PropTypes.shape({
+      preference: PropTypes.object.isRequired,
+      action: PropTypes.object.isRequired
+    })
+  };
+
+  C.displayName = `withPreferences(${Component.displayName})`;
+
+  return C;
+}


### PR DESCRIPTION
Updated Provider to load preferences from localStorage and offer a setPreference callback. Added `withPreferences` hoc wrapper to inject `preferences` object and `setPreference` callback